### PR TITLE
Fixes for running PureCN on small minimal input tests

### DIFF
--- a/R/callLOH.R
+++ b/R/callLOH.R
@@ -90,7 +90,6 @@ callLOH <- function(res, id = 1, arm.cutoff = 0.9) {
         start(res$input$vcf),
         as.character(seqnames(res$input$vcf))), function(x)
         c(min(x), max(x)), c(min=double(1), max=double(1)))))
-
     if (!is.null(centromeres)) {
         # split segments by centromere if available
         chromCoords <- chromCoords[as.integer(match(seqnames(centromeres), rownames(chromCoords))),]
@@ -103,12 +102,17 @@ callLOH <- function(res, id = 1, arm.cutoff = 0.9) {
             c("seqnames", "min", "start")]
         qArms <- centromeres[centromeres$max > centromeres$end,
             c("seqnames", "end", "max")]
-        
+
         colnames(pArms) <- c("chrom", "start", "end")
         colnames(qArms) <- colnames(pArms)
         pArms$arm <- "p"
-        qArms$arm <- "q"
-        armLocations <- rbind(pArms, qArms)
+        if (nrow(qArms) == 0) {
+          armLocations = pArms
+        } else {
+          qArms$arm <- "q"
+          armLocations <- rbind(pArms, qArms)
+        }
+
     } else {
         armLocations <- data.frame(
                             chrom=rownames(chromCoords),

--- a/R/runAbsoluteCN.R
+++ b/R/runAbsoluteCN.R
@@ -605,7 +605,7 @@ runAbsoluteCN <- function(normal.coverage.file = NULL,
     # for sample error.
     targetsPerSegment <- sapply(exon.lrs, length)
     
-    if (!sum(targetsPerSegment > 100, na.rm = TRUE)) {
+    if (!sum(targetsPerSegment > 50, na.rm = TRUE)) {
         .stopRuntimeError("Only tiny segments.")
     }
     


### PR DESCRIPTION
When running PureCN on very small test samples with only a section of
chr22, PureCN failed on two edge cases:

- We get tiny segments below the threshold of 100. These are at 67 so
  lowered this some.
- When calculate chromosome arms, we have a region/fake chromosome that
  doesn't span a full arm. Avoid needing both p and q for this.

These changes hopefully don't break any real cases and help with putting
together automation for running PureCN during unit tests. Thanks much
for all the great work on PureCN and looking into this.