### PR TITLE
Return the exon.lrs variable to the returned list object of runAbsoluteCN()

### DIFF
--- a/R/runAbsoluteCN.R
+++ b/R/runAbsoluteCN.R
@@ -1145,6 +1145,7 @@ runAbsoluteCN <- function(normal.coverage.file = NULL,
     list(
         candidates = candidate.solutions,
         results = results,
+        exon.lrs = exon.lrs,
         input = list(tumor = tumor.coverage.file, normal = normal.coverage.file,
             log.ratio = GRanges(normal[, 1], on.target = normal$on.target, log.ratio = log.ratio),
             log.ratio.sdev = sd.seg, mapd = mapd, vcf = vcf, sampleid = sampleid,

--- a/R/runAbsoluteCN.R
+++ b/R/runAbsoluteCN.R
@@ -1153,7 +1153,7 @@ runAbsoluteCN <- function(normal.coverage.file = NULL,
             mapping.bias.rho = if (is.null(rho) || all(is.na(rho))) NULL else mean(rho, na.rm = TRUE),
             vcf.field.prefix = vcf.field.prefix,
             interval.file = interval.file,
-            exon.lrs = exon.lrs,
+            interval.lrs = exon.lrs,
             args = list(
                 filterVcf = args.filterVcf[vapply(args.filterVcf, object.size, double(1)) < 1000],
                 filterIntervals = args.filterIntervals[vapply(args.filterIntervals, object.size, double(1)) < 1000])

--- a/R/runAbsoluteCN.R
+++ b/R/runAbsoluteCN.R
@@ -1145,7 +1145,6 @@ runAbsoluteCN <- function(normal.coverage.file = NULL,
     list(
         candidates = candidate.solutions,
         results = results,
-        exon.lrs = exon.lrs,
         input = list(tumor = tumor.coverage.file, normal = normal.coverage.file,
             log.ratio = GRanges(normal[, 1], on.target = normal$on.target, log.ratio = log.ratio),
             log.ratio.sdev = sd.seg, mapd = mapd, vcf = vcf, sampleid = sampleid,

--- a/R/runAbsoluteCN.R
+++ b/R/runAbsoluteCN.R
@@ -1154,6 +1154,7 @@ runAbsoluteCN <- function(normal.coverage.file = NULL,
             mapping.bias.rho = if (is.null(rho) || all(is.na(rho))) NULL else mean(rho, na.rm = TRUE),
             vcf.field.prefix = vcf.field.prefix,
             interval.file = interval.file,
+            exon.lrs = exon.lrs,
             args = list(
                 filterVcf = args.filterVcf[vapply(args.filterVcf, object.size, double(1)) < 1000],
                 filterIntervals = args.filterIntervals[vapply(args.filterIntervals, object.size, double(1)) < 1000])


### PR DESCRIPTION
The current implementation of [.optimizeGridPurity()](https://github.com/lima1/PureCN/blob/devel/R/PureCN-internal.R#L669-L681):

```r
.optimizeGridPurity <- function(p) {
    b <- 2 * (1 - p)
    log.ratio.offset <- 0
    lapply(ploidy.grid, function(D) {
        dt <- p/D
        llik.all <- lapply(seq_along(exon.lrs), function(i) .calcLlikSegmentExonLrs(exon.lrs[[i]],
            log.ratio.offset, max.exon.ratio, sd.seg, dt, b, D, test.num.copy))
        subclonal <- vapply(llik.all, which.max, double(1)) == 1
        subclonal.f <- length(unlist(exon.lrs[subclonal]))/length(unlist(exon.lrs))
        if (subclonal.f > max.non.clonal) return(-Inf)
        sum(vapply(llik.all, max, double(1)))
    })
}
```

Returns the total copy number likelihood of a given purity (`p`) and ploidy (`D`) value. The individual segment maximum likelihood values are not available. 

This PR adds the `exon.lrs` to the `input` element of the list that is returned from the `runAbsoluteCN` function call. 

Having the values of this variable available means one can run the `.calcLlikSegmentExonLrs()` function easily. This is helpful for deep diving to understand what segments are driving a higher copy number likelihood for particular purity/ploidy solutions. 

