### PR TITLE
Remove superfluous condition statement on existence of vcf parameter in segmentationPSCBS

### DIFF
--- a/R/segmentationPSCBS.R
+++ b/R/segmentationPSCBS.R
@@ -134,10 +134,8 @@ segmentationPSCBS <- function(normal, tumor, log.ratio, seg, plot.cnv,
                 flavor = flavor, undoTCN = undo.SD, knownSegments = knownSegments, 
                 min.width = 3,alphaTCN = alpha / 2, ...)
             segot <- .PSCBSoutput2DNAcopy(segPSCBSot, sampleid)
-            if (!is.null(vcf)) {
-                segot <- .pruneByHclust(segot, vcf, tumor.id.in.vcf, h = prune.hclust.h,
-                    method = prune.hclust.method, chr.hash = chr.hash)
-            }
+            segot <- .pruneByHclust(segot, vcf, tumor.id.in.vcf, h = prune.hclust.h,
+                method = prune.hclust.method, chr.hash = chr.hash)
             segot <- segot[segot$num.mark > 3 &
                            segot$num.mark <= boost.on.target.max.size, 2:4]
             colnames(segot) <- colnames(knownSegments)[1:3]
@@ -166,10 +164,8 @@ segmentationPSCBS <- function(normal, tumor, log.ratio, seg, plot.cnv,
     if (plot.cnv) PSCBS::plotTracks(segPSCBS)
     segPSCBS <- NULL
 
-    if (!is.null(vcf)) {
-        seg <- .pruneByHclust(seg, vcf, tumor.id.in.vcf, h = prune.hclust.h,
-            method = prune.hclust.method, chr.hash = chr.hash)
-    }
+    seg <- .pruneByHclust(seg, vcf, tumor.id.in.vcf, h = prune.hclust.h,
+        method = prune.hclust.method, chr.hash = chr.hash)
     seg <- .addAverageWeights(seg, weight.flag.pvalue, tumor, chr.hash)
     seg <- .fixBreakpointsInBaits(tumor, log.ratio, seg, chr.hash)
     attr(seg, "PSCBS.Args") <- list(


### PR DESCRIPTION
This PR removes the following superfluous condition statements from the `segmentationPSCBS()` function:

```r
if (!is.null(vcf)) {
```

Before this condition statement is run, the function `.PSCBSinput()` is run to generate inputs for PSCBS. This function has the following condition statement:

```r
if (is.null(vcf)) {
    .stopUserError("segmentationPSCBS requires VCF file.")
}
```

As such, checking for whether the parameter `vcf` is set has already happened upstream. 

Additionally, this condition statement determines where `.pruneByHclust()` is run. But PSCBS has already been run potentially 2 times before this function is run. Since, PSCBS can't be run without a VCF file (more specifically BAF values) this condition statement will always evaluate to TRUE making it both confusing and superfluous. 