### PR TITLE
use --bai option value when a single bam file is provided as input

### DIFF
--- a/inst/extdata/Coverage.R
+++ b/inst/extdata/Coverage.R
@@ -190,6 +190,7 @@ if (!is.null(bam.file)) {
         }
     } else {
         bamFiles <- bam.file
+        indexFiles <- index.file
     }
     if (length(bamFiles) != length(indexFiles) && !is.null(indexFiles)) {
         stop("List of BAM files and BAI files of different length.")


### PR DESCRIPTION
Fixes #272 

The current code only honors the `--bai` option when a bam file list is provided. This PR passes the `--bai` value along when a single bam file is given as input.